### PR TITLE
lzmq minimal version added to rockspec

### DIFF
--- a/itorch-scm-1.rockspec
+++ b/itorch-scm-1.rockspec
@@ -22,7 +22,7 @@ dependencies = {
    "lbase64",
    "env",
    "image",
-   "lzmq"
+   "lzmq >= 0.4.2"
 }
 
 build = {


### PR DESCRIPTION
In case someone else has a problem with old install #6 (there are some in our lab)
