### PR TITLE
add util.msg utility for building messages

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -52,9 +52,31 @@ local function ipyEncodeAndSend(sock, m)
    -- print(o)
    zassert(sock:send_all(o))
 end
+
+local session_id = uuid.new()
+-- function for creating a new message object
+local function msg(msg_type, parent)
+   local m = {}
+   m.header = {}
+   if parent then
+      m.uuid = parent.uuid
+      m.parent_header = parent.header
+   else
+      m.parent_header = {}
+   end
+   m.header.msg_id = uuid.new()
+   m.header.msg_type = msg_type
+   m.header.session = session_id
+   m.header.date = os.date("%Y-%m-%dT%H:%M:%S")
+   m.header.username = 'itorch'
+   m.content = {}
+   return m
+end
+
 ---------------------------------------------------------------------------
 
 util.ipyDecode = ipyDecode
 util.ipyEncodeAndSend = ipyEncodeAndSend
+util.msg = msg
 
 return util


### PR DESCRIPTION
initializing by copying the parent message creates invalid values

This fixes protocol compatibility with upcoming IPython 3.0 release, which speaks an updated protocol version, and can talk down to protocol v4.0. The copying behavior caused the kernel to claim to be speaking the latest v5.0 protocol.
