### PR TITLE
possible error in IOHandler.lua

### DIFF
--- a/IOHandler.lua
+++ b/IOHandler.lua
@@ -50,6 +50,7 @@ do
       local portnum_f = torch.DiskFile(arg[3],'r')
       portnum_f:quiet()
       rawpub_port = portnum_f:readInt()
+      if portnum_f:hasError() then rawpub_port = 0 end
       portnum_f:close()
    end
 end


### PR DESCRIPTION
itorch_launcher starts two processes (main and IOHandler) with arg $IO_PORTNUM,
"main" writes an io port number into that file while "IOHandler" tries to read the file in a loop.
Possible error:
if "IOHandler" reads the file before written by "main", gets a read error with an invalid value in variable "rawpub_port", connects that invalid port and goes into loop
