### PR TITLE
Explicitly set the IPython kernel message protocol to 4.0 (for IPython 3)

### DIFF
--- a/IOHandler.lua
+++ b/IOHandler.lua
@@ -73,7 +73,7 @@ function handleSTDO(ev)
 	 o.header = tablex.deepcopy(kvstore.current_msg.header)
 	 o.header.msg_id = uuid.new()
 	 o.header.msg_type = 'pyout'
-    o.header.version = "4.0"
+	 o.header.version = "4.0"
 	 o.content = {
 	    data = {},
 	    metadata = {},

--- a/IOHandler.lua
+++ b/IOHandler.lua
@@ -67,22 +67,16 @@ function handleSTDO(ev)
    if nbytes > 0 then
       local output = ffi.string(buffer, nbytes)
       if kvstore.current_msg then
-	 local o = {}
-	 o.uuid = kvstore.current_msg.uuid
-	 o.parent_header = kvstore.current_msg.header
-	 o.header = tablex.deepcopy(kvstore.current_msg.header)
-	 o.header.msg_id = uuid.new()
-	 o.header.msg_type = 'pyout'
-	 o.header.version = "4.0"
-	 o.content = {
-	    data = {},
-	    metadata = {},
-	    execution_count = kvstore.exec_count
-	 }
-	 o.content.data['text/plain'] = output
-	 util.ipyEncodeAndSend(iopub, o)
+         local o = util.msg('pyout', kvstore.current_msg)
+         o.content = {
+            data = {},
+            metadata = {},
+            execution_count = kvstore.exec_count
+          }
+         o.content.data['text/plain'] = output
+         util.ipyEncodeAndSend(iopub, o)
       else
-	 print(output)
+         print(output)
       end
    end
    ev:set_interval(1)
@@ -93,20 +87,20 @@ function handleRawPub(sock)
    -- if this message is a key-value from main.lua
    if m[1] == 'private_msg' then
       if m[2] == 'current_msg' then
-	 kvstore[m[2]] = json.decode(m[3])
+         kvstore[m[2]] = json.decode(m[3])
       elseif m[2] == 'exec_count' then
-	 kvstore[m[2]] = tonumber(m[3])
+         kvstore[m[2]] = tonumber(m[3])
       elseif m[2] == 'shutdown' then
-	 sock:send('ACK')
-	 loop:stop()
-	 iopub:close()
-	 rawpub:close()
-	 heartbeat:close()
-	 ffi.C.close(io_stdo)
-	 os.execute('rm -f ' .. arg[2]) -- cleanup files
-	 os.execute('rm -f ' .. arg[3]) 
-	 print('Shutting down iTorch')
-	 os.exit()
+         sock:send('ACK')
+         loop:stop()
+         iopub:close()
+         rawpub:close()
+         heartbeat:close()
+         ffi.C.close(io_stdo)
+         os.execute('rm -f ' .. arg[2]) -- cleanup files
+         os.execute('rm -f ' .. arg[3]) 
+         print('Shutting down iTorch')
+         os.exit()
       end
       sock:send('ACK')
       return

--- a/IOHandler.lua
+++ b/IOHandler.lua
@@ -73,6 +73,7 @@ function handleSTDO(ev)
 	 o.header = tablex.deepcopy(kvstore.current_msg.header)
 	 o.header.msg_id = uuid.new()
 	 o.header.msg_type = 'pyout'
+     o.header.version = "4.0"
 	 o.content = {
 	    data = {},
 	    metadata = {},

--- a/IOHandler.lua
+++ b/IOHandler.lua
@@ -73,7 +73,7 @@ function handleSTDO(ev)
 	 o.header = tablex.deepcopy(kvstore.current_msg.header)
 	 o.header.msg_id = uuid.new()
 	 o.header.msg_type = 'pyout'
-     o.header.version = "4.0"
+    o.header.version = "4.0"
 	 o.content = {
 	    data = {},
 	    metadata = {},


### PR DESCRIPTION
IPython 3 will send messages marked as version 5.0 (this may be a bug). 

By copying the header from the previous message, iTorch will set the message version to 5.0.
For 'pyout' messages (stdout), this will cause IPython to skip adapting
(converting) them from v4 to v5 and they will get silently dropped.
