### PR TITLE
Add HMAC signature and adapt to Python 3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ We follow the [Torch-7](https://github.com/torch/torch7/blob/master/CONTRIBUTING
 
 ## Pull Requests
 We actively welcome your pull requests.
+
 1. Fork the repo and create your branch from `master`. 
 2. If you've added code that should be tested, add tests
 3. If you've changed APIs, update the documentation. 

--- a/IOHandler.lua
+++ b/IOHandler.lua
@@ -12,9 +12,9 @@ require 'env'
 local zmq = require 'lzmq'
 local zloop = require 'lzmq.loop'
 local zassert = zmq.assert
-local json=require 'cjson'
+local json = require 'cjson'
 local uuid = require 'uuid'
-local ffi = require'ffi'
+local ffi = require 'ffi'
 local util = require 'itorch.util'
 local context = zmq.context()
 local tablex = require 'pl.tablex'

--- a/IOHandler.lua
+++ b/IOHandler.lua
@@ -12,7 +12,7 @@ require 'env'
 local zmq = require 'lzmq'
 local zloop = require 'lzmq.loop'
 local zassert = zmq.assert
-local json = require 'cjson'
+local json=require 'cjson'
 local uuid = require 'uuid'
 local ffi = require 'ffi'
 local util = require 'itorch.util'
@@ -25,6 +25,9 @@ local ipyfile = assert(io.open(arg[1], "rb"), "Could not open iPython config")
 local ipyjson = ipyfile:read("*all")
 ipyfile:close()
 local ipycfg = json.decode(ipyjson)
+--------------------------------------------------------------
+-- set session key
+util.setSessionKey(ipycfg.key)
 --------------------------------------------------------------
 --- The libc functions used by this process (for non-blocking IO)
 ffi.cdef[[

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ plot = Plot():histogram(torch.randn(10000)):draw()
 
 ## Requirements
 iTorch requires or works with
-* Mac OS X or Linux (tested in Ubuntu 14.04)
+* Mac OS X or Linux (tested in Ubuntu 14.04 and Arch Linux)
 * [Torch-7](https://github.com/torch/torch7/wiki/Cheatsheet#installing-and-running-torch)
 * [IPython](http://ipython.org/install.html) version 2.2 or above (you can check your version of ipython using ipython --version)
 * ZeroMQ

--- a/itorch
+++ b/itorch
@@ -11,7 +11,7 @@ elif [ $(ipython --version|cut -f1 -d'.') = 3 ]; then
     if [ $mode = "console" ]; then
 	ipython $mode --profile torch $@
     else
-	ipython $mode --MappingKernelManager.default_kernel_name="itorch" --Session.key='' $@
+	ipython $mode --MappingKernelManager.default_kernel_name="itorch" $@
     fi
 else
     echo "Unsupported ipython version. Only major versions 2.xx or 3.xx are supported"

--- a/util.lua
+++ b/util.lua
@@ -15,6 +15,12 @@ local crypto = require 'crypto'
 
 local util = {}
 --------------------------------------------------------------
+-- Signature Key and its setter
+local session_key = ''
+local function setSessionKey(key)
+   session_key = key
+end
+--------------------------------------------------------------
 -- Common decoder function for all messages (except heartbeats which are just looped back)
 local function ipyDecode(sock, m)
    m = m or zassert(sock:recv_all())
@@ -40,9 +46,9 @@ local function ipyDecode(sock, m)
 end
 -- Common encoder function for all messages (except heartbeats which are just looped back)
 -- See http://ipython.org/ipython-doc/stable/development/messaging.html
-local function ipyEncodeAndSend(sock, m, key)
+local function ipyEncodeAndSend(sock, m)
    -- Message digest (for HMAC signature)
-   local d = crypto.hmac.new('sha256', key)
+   local d = crypto.hmac.new('sha256', session_key)
    d:update(json.encode(m.header))
    if m.parent_header then d:update(json.encode(m.parent_header)) else d:update('{}') end
    if m.metadata then d:update(json.encode(m.metadata)) else d:update('{}') end
@@ -87,5 +93,6 @@ end
 util.ipyDecode = ipyDecode
 util.ipyEncodeAndSend = ipyEncodeAndSend
 util.msg = msg
+util.setSessionKey = setSessionKey
 
 return util


### PR DESCRIPTION
### Add signature to zmq messages (HMAC digest)

So we can remove option `--Session.key=''` in call to ipython
And so we fix #41 since it then supports Python 3

/!\ Signature of `util.ipyEncodeAndSend` changed:
I added the session key as thrid argument.

/!\ New dependency: luacrypto
Where do I have to notify it?

/!\ `d:final()` used instead of `d:digest()`
According to the [documentation](http://luacrypto.luaforge.net/manual.html#reference), `hmac` object should have a `digest` method, but it is in fact named `final`.
### Add some missing spaces
### Fix formatting issue in `CONTRIBUTING.md`
### Add Arch Linux to the list of tested systems

_NB: I read the guidelines for contributing, but:_
1. I could not run test.lua in its own. I do I run tests?
2. I changed the API of a fonction, but there is actually no documentation to change.
3. The code I patch use 3 space indentation, so I respected it despite the guidelines.
4. Same for the 80 characters constraint.
