### PR TITLE
Added support for iPython 4.xx (Jupyter)

### DIFF
--- a/itorch
+++ b/itorch
@@ -5,14 +5,20 @@ if [ -z "$mode" ]; then
 else
     shift
 fi
-VERSION := $(ipython --version|cut -f1 -d'.')
-if [ $VERSION = 2 ]; then
+v=$(ipython --version|cut -f1 -d'.')
+if [ $v = 2 ]; then
     ipython $mode --profile torch $@
-elif [ $VERSION = 3 or || $VERSION = 4 ]; then
-    if [ $mode = "console" ]; then
-	ipython $mode --profile torch $@
+elif [ $v = 3 ]; then
+    if [ $v = "console" ]; then
+	     ipython $mode --profile torch $@
     else
-	ipython $mode --MappingKernelManager.default_kernel_name="itorch" $@
+	     ipython $mode --MappingKernelManager.default_kernel_name="itorch" $@
+    fi
+elif [ $v = 4 ]; then
+    if [ $mode = "console" ]; then
+      jupyter console --kernel=itorch $@
+    else
+      ipython $mode --MappingKernelManager.default_kernel_name="itorch" $@
     fi
 else
     echo "Unsupported ipython version. Only major versions 2.xx, 3.xx, or 4.xx (Jupyter) are supported"

--- a/itorch
+++ b/itorch
@@ -5,14 +5,15 @@ if [ -z "$mode" ]; then
 else
     shift
 fi
-if [ $(ipython --version|cut -f1 -d'.') = 2 ]; then
+VERSION := $(ipython --version|cut -f1 -d'.')
+if [ $VERSION = 2 ]; then
     ipython $mode --profile torch $@
-elif [ $(ipython --version|cut -f1 -d'.') = 3 ]; then
+elif [ $VERSION = 3 or || $VERSION = 4 ]; then
     if [ $mode = "console" ]; then
 	ipython $mode --profile torch $@
     else
 	ipython $mode --MappingKernelManager.default_kernel_name="itorch" $@
     fi
 else
-    echo "Unsupported ipython version. Only major versions 2.xx or 3.xx are supported"
+    echo "Unsupported ipython version. Only major versions 2.xx, 3.xx, or 4.xx (Jupyter) are supported"
 fi


### PR DESCRIPTION
The iTorch kernel is compatible with Jupyter, so I wanted to enable it from the `itorch` command. Also, the Development branch of iPython has been around for some time now (4.0.0-dev), which uses Jupyter as a backend. 

Tested with `itorch console` and `itorch notebook`
