### PR TITLE
Fix JS escaping in itorch.html()

### DIFF
--- a/gfx.lua
+++ b/gfx.lua
@@ -151,12 +151,12 @@ local html_template =
 ]]
 
 local function escape_js(s)
+   -- backslash
+   s = s:gsub("\\","\\\\")
    -- single quite
    s = s:gsub("'","\'")
    -- double quote
    s = s:gsub('"','\"')
-   -- backslash
-   s = s:gsub("\\","\\\\")
    -- newline
    s = s:gsub("\n","\\n")
    -- carriage return


### PR DESCRIPTION
We need to escape backslash first. Otherwise, other special chars are
handled incorrectly – backslash that is a result of escaping is escaped
as well and that's not what we want.
