### PR TITLE
itorch_launcher: portable test for existence of luajit

### DIFF
--- a/itorch_launcher
+++ b/itorch_launcher
@@ -4,8 +4,7 @@ currdir=$(cd "$currdir" && pwd)
 
 # Support qtlua, if it is available
 LUA=$currdir/luajit
-ls $LUA >/dev/null 2>&1
-if [ $? == 1 ]; then
+if test ! -x "$LUA"; then
     LUA=$currdir/lua
 fi
 


### PR DESCRIPTION
The itorch launcher tests the existences of luajit. If luajit
does not exist, lua is launched instead. The test does not work
on debian bash. I made a standard portable file existance test.
