### PR TITLE
Allow redef of torch classes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,5 +11,20 @@ itorch=require 'itorch._env'
 require 'itorch.gfx'
 require 'itorch.bokeh'
 itorch.Plot=require 'itorch.Plot'
+
+local _class = torch.class
+torch.class = function(name, parentName, module)
+  if name ~= nil then
+    debug.getregistry()[name] = nil
+  end
+  if module ~= nil then
+    return _class(name, parentName, module)
+  elseif parentName ~= nil then
+    return _class(name, parentName)
+  else
+    return _class(name)
+  end
+end
+
 return itorch
 


### PR DESCRIPTION
Running code that defines classes using `torch.class` in an interactive environment leads to the well-intentioned but undesirable `parent class/factor is already defined` error. 

This PR introduces a hacky workaround that silently unsets the existing class if it already exists.
