### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ itorch.html('<p>magic!</p>', window_id)
 ```
 ![screenshot](screenshots/html.png "")
 
-###Plotting
+### Plotting
 iTorch can plot to screen in notebook mode, or save the plot to disk as a html file.
 
 A Plot object is introduced, that can plot different kinds of plots such as scatter, line, segment, quiver plots.  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
